### PR TITLE
トップページの実装２

### DIFF
--- a/app/assets/javascripts/trend.js
+++ b/app/assets/javascripts/trend.js
@@ -1,0 +1,27 @@
+$(document).on('ready pjax:success',function(){
+
+  //トップページの「もっと見る」をクリックすると該当の「もっと見る」の項目を遷移先ページで選択ずみの状態にする
+  $(".more").on('click', function(e) {
+    var title = $(e.target).parents('.title_bar').find("h3").text();
+    if( title == "NEW ALBUMS" ){
+      $(document).on('ready pjax:success',function(){
+        $("a[href = '#new_albums']").click();
+      });
+    }else if( title == "おすすめアーティスト" ){
+      $(document).on('ready pjax:success',function(){
+        $("a[href = '#reccomend_artists']").click();
+      });
+    }
+  });
+
+  //トレンドページのタイトル名の切り替え
+  $(".nav-tabs a").on('click', function(e) {
+    e.preventDefault();
+    var id = $(this).attr('href');
+    if( id === "#new_albums" ){
+      $(".trend-title > h2").text("NEW ALBUMS");
+    }else if( id === "#reccomend_artists" ){
+      $(".trend-title > h2").text("おすすめアーティスト");
+    }
+  });
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,7 @@
 @import "search";
 @import "genre";
 @import "toppage";
+@import "trend";
 
 //ヘッダーを常に上で固定
 body {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "mypage";
 @import "search";
 @import "genre";
+@import "toppage";
 
 //ヘッダーを常に上で固定
 body {

--- a/app/assets/stylesheets/caption.scss
+++ b/app/assets/stylesheets/caption.scss
@@ -9,6 +9,29 @@
     float: left;
     width: 140px;
   }
+  //横長のサムネ
+  .new_thumb{
+    float: left;      //各サムネイルの横並び
+    margin-top: 20px;
+    margin-left: 26px;
+    width: 306px;
+    display: flex;    //写真の横に曲の情報を表示
+    figure{
+      width: 70px;
+      margin-right: 12px;
+      figcaption{
+        width: 70px;
+      }
+    }
+    .info{
+      display: flex;
+      align-items: center;
+      h6{
+        margin: 0;
+        margin-bottom: 5px;
+      }
+    }
+  }
 }
 //キャプション 参考 http://www.nxworld.net/tips/css-only-caption-effect.html#anchor01
 figure {

--- a/app/assets/stylesheets/toppage.scss
+++ b/app/assets/stylesheets/toppage.scss
@@ -1,0 +1,18 @@
+.title_bar{
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 30px;
+  h3{
+    margin: 0;
+  }
+  a{
+    button,button:hover,button:focus{
+    color: #999;
+    background-color:white;
+    border-radius: 18px;
+    border: 1px solid #d0d0d0;
+    }
+  }
+
+}

--- a/app/assets/stylesheets/toppage.scss
+++ b/app/assets/stylesheets/toppage.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin-top: 30px;
+  margin-top: 50px;
   h3{
     margin: 0;
   }
@@ -14,5 +14,5 @@
     border: 1px solid #d0d0d0;
     }
   }
-
 }
+.midline{margin-top:50px;}

--- a/app/assets/stylesheets/trend.scss
+++ b/app/assets/stylesheets/trend.scss
@@ -1,0 +1,11 @@
+.trend-title{
+  margin-top: 50px;
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: row;
+  .txt{
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,6 +1,7 @@
 class SongsController < ApplicationController
   def index
     @rankings = Song.includes(:album).order(play_count: :desc).limit(6)
+    @new_albums = Album.order(release_date: :desc).limit(9)
   end
 
   def new

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -2,6 +2,7 @@ class SongsController < ApplicationController
   def index
     @rankings = Song.includes(:album).order(play_count: :desc).limit(6)
     @new_albums = Album.order(release_date: :desc).limit(9)
+    @reccomend_artists = Artist.all.select{|a|a.reccomend?}.take(6)
   end
 
   def new

--- a/app/controllers/songs_controller.rb
+++ b/app/controllers/songs_controller.rb
@@ -1,6 +1,6 @@
 class SongsController < ApplicationController
   def index
-    @songs = Song.includes(:album).all
+    @rankings = Song.includes(:album).order(play_count: :desc).limit(6)
   end
 
   def new

--- a/app/controllers/trend_controller.rb
+++ b/app/controllers/trend_controller.rb
@@ -1,0 +1,4 @@
+class TrendController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/trend_controller.rb
+++ b/app/controllers/trend_controller.rb
@@ -1,4 +1,6 @@
 class TrendController < ApplicationController
   def index
+    @new_albums = Album.order(release_date: :desc)
+    @reccomend_artists = Artist.all.select{|a|a.reccomend?}
   end
 end

--- a/app/views/songs/_new_album.html.haml
+++ b/app/views/songs/_new_album.html.haml
@@ -1,0 +1,10 @@
+.new_thumb
+  %figure
+    =image_tag(album.album_image.url,class:"thumb_image")
+    %figcaption
+      = link_to album_path(album) do
+        = image_tag(album.album_image.url,class:"thumb_image thumb_caption")
+  .info
+    .txt
+      %h6= link_to album.name,album_path(album)
+      %h6= link_to album.artist.name,artist_path(album.artist),style:"color: #969696;"

--- a/app/views/songs/_title_bar.html.haml
+++ b/app/views/songs/_title_bar.html.haml
@@ -1,6 +1,6 @@
 .title_bar
   %h3= title
-  = link_to path do
+  = link_to path,class:"more" do
     %button.btn.btn-sm.btn-default
       もっと見る
       %span.glyphicon.glyphicon-chevron-right

--- a/app/views/songs/_title_bar.html.haml
+++ b/app/views/songs/_title_bar.html.haml
@@ -1,0 +1,6 @@
+.title_bar
+  %h3= title
+  = link_to path do
+    %button.btn.btn-sm.btn-default
+      もっと見る
+      %span.glyphicon.glyphicon-chevron-right

--- a/app/views/songs/index.html.haml
+++ b/app/views/songs/index.html.haml
@@ -12,6 +12,12 @@
   = render partial: "songs/title_bar", locals: {title: "ランキング",path:"/rankings"}
   .thumb-container
     = render @rankings
+.container
+  = render partial: "songs/title_bar", locals: {title: "NEW ALBUMS",path:"/"}
+  .thumb-container
+    - @new_albums.each do |album|
+      = render partial: "songs/new_album", locals: {album: album}
+%hr.midline
 / チケットモーダル トリガー
 %a#ticket_modal_trigger{"data-target" => "#ticket_modal", "data-toggle" => "modal"}
 / チケットモーダル 内容

--- a/app/views/songs/index.html.haml
+++ b/app/views/songs/index.html.haml
@@ -13,13 +13,13 @@
   .thumb-container
     = render @rankings
 .container
-  = render partial: "songs/title_bar", locals: {title: "NEW ALBUMS",path:"/"}
+  = render partial: "songs/title_bar", locals: {title: "NEW ALBUMS",path:"/trend"}
   .thumb-container
     - @new_albums.each do |album|
       = render partial: "songs/new_album", locals: {album: album}
 %hr.midline
 .container
-  = render partial: "songs/title_bar", locals: {title: "おすすめアーティスト",path:"/"}
+  = render partial: "songs/title_bar", locals: {title: "おすすめアーティスト",path:"/trend"}
   .thumb-container
     = render @reccomend_artists
 / チケットモーダル トリガー

--- a/app/views/songs/index.html.haml
+++ b/app/views/songs/index.html.haml
@@ -11,7 +11,7 @@
 .container
   = render partial: "songs/title_bar", locals: {title: "ランキング",path:"/rankings"}
   .thumb-container
-    = render @songs
+    = render @rankings
 / チケットモーダル トリガー
 %a#ticket_modal_trigger{"data-target" => "#ticket_modal", "data-toggle" => "modal"}
 / チケットモーダル 内容

--- a/app/views/songs/index.html.haml
+++ b/app/views/songs/index.html.haml
@@ -9,6 +9,7 @@
     =link_to "#" do
       =image_tag("carousel_3.png")
 .container
+  = render partial: "songs/title_bar", locals: {title: "ランキング",path:"/rankings"}
   .thumb-container
     = render @songs
 / チケットモーダル トリガー

--- a/app/views/songs/index.html.haml
+++ b/app/views/songs/index.html.haml
@@ -18,6 +18,10 @@
     - @new_albums.each do |album|
       = render partial: "songs/new_album", locals: {album: album}
 %hr.midline
+.container
+  = render partial: "songs/title_bar", locals: {title: "おすすめアーティスト",path:"/"}
+  .thumb-container
+    = render @reccomend_artists
 / チケットモーダル トリガー
 %a#ticket_modal_trigger{"data-target" => "#ticket_modal", "data-toggle" => "modal"}
 / チケットモーダル 内容

--- a/app/views/trend/index.html.haml
+++ b/app/views/trend/index.html.haml
@@ -1,0 +1,17 @@
+.container
+  .trend-title
+    = embedded_svg("genre_title.svg")
+    %h2.txt NEW ALBUMS
+  %ul.nav.nav-tabs
+    %li.active
+      =link_to "NEW ALBUMS","#new_albums", data: { toggle: 'tab' }
+    %li
+      =link_to "おすすめアーティスト","#reccomend_artists", data: { toggle: 'tab' }
+  /NEW ALBUMS
+  .tab-content
+    .tab-pane.active#new_albums
+      NEW ALBUMS
+  /おすすめアーティスト
+  .tab-content
+    .tab-pane#reccomend_artists
+      おすすめアーティスト

--- a/app/views/trend/index.html.haml
+++ b/app/views/trend/index.html.haml
@@ -10,8 +10,10 @@
   /NEW ALBUMS
   .tab-content
     .tab-pane.active#new_albums
-      NEW ALBUMS
+      .thumb-container
+        = render @new_albums
   /おすすめアーティスト
   .tab-content
     .tab-pane#reccomend_artists
-      おすすめアーティスト
+      .thumb-container
+        = render @reccomend_artists

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,6 @@ Rails.application.routes.draw do
   resources :follows, only: [:create,:destroy]
   resources :fav_songs, only: [:create,:destroy]
   resources :fav_albums, only: [:create,:destroy]
+  resources :trend, only: :index
   root 'songs#index'
 end

--- a/db/migrate/20170222225608_add_reccomend_to_artist.rb
+++ b/db/migrate/20170222225608_add_reccomend_to_artist.rb
@@ -1,0 +1,5 @@
+class AddReccomendToArtist < ActiveRecord::Migration
+  def change
+    add_column :artists, :reccomend, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170211022355) do
+ActiveRecord::Schema.define(version: 20170222225608) do
 
   create_table "albums", force: :cascade do |t|
     t.string   "name",         limit: 255
@@ -28,8 +28,9 @@ ActiveRecord::Schema.define(version: 20170211022355) do
     t.string   "name",         limit: 255
     t.string   "artist_image", limit: 255
     t.integer  "genre_id",     limit: 4
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.datetime "created_at",                               null: false
+    t.datetime "updated_at",                               null: false
+    t.boolean  "reccomend",                default: false, null: false
   end
 
   add_index "artists", ["genre_id"], name: "index_artists_on_genre_id", using: :btree


### PR DESCRIPTION
# WHAT
トップページに曲のランキングとニューアルバム、おすすめアーティストを表示する
また、それぞれに「もっと見る」のリンクをつける。
「もっと見る」の遷移先ページ（trend#index）も作成する

# WHY
流行ってる曲などをトップページから確認しやすくするため